### PR TITLE
updated deprecated API, extensions/v1beta1

### DIFF
--- a/01-pods-deployments.md
+++ b/01-pods-deployments.md
@@ -143,7 +143,7 @@ The contents of `support-files/nginx-simple-deployment.yaml` are as follows:
 
 ```shell
 # a comment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx


### PR DESCRIPTION
Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served